### PR TITLE
fix: vite bundler template has black bar above #app, #app is not completely fullscreen on mobile

### DIFF
--- a/templates/template-bundler-vite/public/style.css
+++ b/templates/template-bundler-vite/public/style.css
@@ -7,7 +7,7 @@ body {
 
 #app {
     width: 100%;
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
this is because running the website on mobile (at least for me, Google Chrome on Android, Sony Xperia 1 V) leaves a black bar on top of the game, with `#app` not completely filling up the entire screen

a one-liner from `100vh` to `100dvh` fixed the problem for me